### PR TITLE
doc: add new sections to README for new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ Questo modello di relazione d'esame di Didattica dell'Informatica è stato utili
 
 Puoi vedere il risultato pubblicato [qui](https://daniele-tentoni.github.io/cs-teaching-exam-template/).
 
+**Tabella dei contenuti**:
+
+- [Compilare la relazione](#compilare-la-relazione)
+- [Licenza](#licenza)
+  - [Reuse](#reuse)
+- [Contribuitre](#contribuire)
+
 ## Compilare la relazione
 
 Compila la relazione in Markdown utilizzando [pandoc](https://pandoc.org):
@@ -26,6 +33,35 @@ mkdir dist
 pandoc esame/esame.md --from=markdown --to=html --output=dist/index.html --toc --template=elegant_bootstrap_menu.html --data-dir=.pandoc
 ```
 
+Per effettuare il deploy automatico su un sito su Github Pages, hai bisogno di creare un token segreto per permettere alla Github Actions di accedere con permessi di scrittura al repository di destinazione sul branch _gh-pages_. Per fare questo, puoi seguire i seguenti passi:
+
+1. Andare nelle impostazioni del proprio profilo: `Avatar` -> `Impostazioni` -> `Opzioni Sviluppatore` -> `Personal Access Token`
+2. Creare un nuovo Personal Access Token con i diritti repo_admin **da non condividere con nessuno** (chiunque possederà questo codice potrà scrivere qualunque cosa sul vostro repository)
+3. Andare sul proprio repository appena creato, `Impostazioni` -> `Secrets` -> `Actions`
+4. Creare un nuovo segreto dal nome `GH_TOKEN`, incollare il token generato e salvare
+
+Ogni volta che verrà effettuata una push sul branch principale verrà effettuato un deploy tutto in automatico.
+
+## Licenza
+
+Il materiale di questo repository è protetto, salvo se diversamente specificato, da licenza GPL 3.0 disponibile [qui](/LICENSES/GPL-3.0-only.txt).
+
+La relazione d'esame d'esempio proposta in `esame/esame.md` è la stessa proposta dal prof. Michael Lodi per il relativo corso [qui](https://github.com/CSEd-unibo/CSEd-unibo.github.io/blob/master/modello_esame.md) di pubblico dominio.
+
+### [Reuse](https://reuse.software/)
+
+Reuse è un progetto che aiuta a mantenere le license software e renderle chiare e accessibili per umani e computers. Puoi ottenere maggiori informazioni sul [sito ufficiale](https://reuse.software/) del progetto.
+
+Ogni volta che verrà effettuata una push o verrà aperta una pull request verso il branch principale, verrà controllato se ogni file dentro al progetto è correttamente licenziato o meno. Per ulteriori informazioni a riguardo, leggi [qui](https://github.com/marketplace/actions/reuse-compliance-check).
+
+In ogni momento puoi controllare che il tuo lavoro sia conforme alle [specifiche](https://reuse.software/spec/) tramite l'uso del [tool dedicato](https://github.com/fsfe/reuse-tool):
+
+    reuse lint
+
+Il tool permette anche di aggiungere gli headers specifici per ogni tipo di file tramite dei comandi appositi:
+
+    reuse addheader --copyright=<your_name> --license=<desired_license> file
+
 ## Contribuire
 
 Puoi contribuire a questo repository template aprendo issues o pull requests.
@@ -33,5 +69,3 @@ Puoi contribuire a questo repository template aprendo issues o pull requests.
 Come contributi interessanti da portare avanti ci sarebbero quello di creare un Makefile per semplificare le operazioni più ripetitive oppure quello di aggiungere il supporto almeno per Latex nel caso qualche altro studente ne avesse bisogno. Io ho usato il Markdown.
 
 E ovviamente traducendo in Inglese questo file.
-
-La relazione d'esame d'esempio proposta in `esame/esame.md` è la stessa proposta dal prof. Michael Lodi per il relativo corso [qui](https://github.com/CSEd-unibo/CSEd-unibo.github.io/blob/master/modello_esame.md).


### PR DESCRIPTION
Add secret pat `GH_TOKEN` creation section to let new users deploy on Github Pages their artifacts and the `Reuse` section for commands to use to adhere to reuse specification.

Close #2.